### PR TITLE
支持属性为 LocalDateTime、BigInteger 等复杂类型

### DIFF
--- a/src/site/forgus/plugins/apigenerator/util/FieldUtil.java
+++ b/src/site/forgus/plugins/apigenerator/util/FieldUtil.java
@@ -37,6 +37,8 @@ public class FieldUtil {
         normalTypes.put("String", "@string");
         normalTypes.put("Date", new Date().getTime());
         normalTypes.put("BigDecimal", 0.111111);
+        normalTypes.put("LocalDateTime", "yyyy-MM-dd HH:mm:ss");
+        normalTypes.put("BigInteger", 0);
         genericList.add("T");
         genericList.add("E");
         genericList.add("K");


### PR DESCRIPTION
如果实体类属性中有 jdk自带LocalDateTime、BigInteger 类型属性的时候，插件生成的YAPI json5 数据会出现错误，主要的错误，属性注释会出现错位或不显示，之前反馈过一个[issue](https://github.com/Forgus/api-generator/issues/21)，阅读了您的源码，在`normalTypes`里增加了这两种类型支持，测试了下，应该没啥大问题
```json
{
  "code": 0,//状态码
  "message": "@string",//返回内容
  "data": {//返回数据
    "orderId": 1,//预约单id
    "reserveOpenId": "@string",//预约人微信openid
    "deviceId": 0,//预约设备id，BigInteger类型
    "deviceName": "@string",//预约设备名称
    "reserveTime": "@string",//预约时间
    "applyContactPhone": "@string",//预约联系电话
    "applyUserName": "@string",//预约人姓名
    "applyAddress": "@string",//预约地址
    "departmentId": 0,//办公室id
    "departmentName": "@string",//办公室名称
    "status": 1,//状态，1正常，0作废
    "remark": "@string",//备注
    "createTime": "yyyy-MM-dd HH:mm:ss",//创建时间，LocalDateTime类型
    "updateTime": "yyyy-MM-dd HH:mm:ss",//更新时间，LocalDateTime类型
    "version": 1//版本号
  }
}
```