### PR TITLE
修复@RestController注解指定value的时候，报Invalid Class File的问题

### DIFF
--- a/src/site/forgus/plugins/apigenerator/ApiGenerateAction.java
+++ b/src/site/forgus/plugins/apigenerator/ApiGenerateAction.java
@@ -247,7 +247,7 @@ public class ApiGenerateAction extends AnAction {
         PsiAnnotation classRequestMapping = null;
         for (PsiAnnotation annotation : containingClass.getAnnotations()) {
             String text = annotation.getText();
-            if (text.endsWith(WebAnnotation.Controller)) {
+            if (text.contains(WebAnnotation.Controller)) {
                 controller = annotation;
             } else if (text.contains(WebAnnotation.RequestMapping)) {
                 classRequestMapping = annotation;


### PR DESCRIPTION
这个[issue](https://github.com/Forgus/api-generator/issues/19)反馈的问题，实际上我也有遇到，定位了下问题，发现对于 `@RestController(value = "myTestController")` 指定value的RestController注解，会出现`Invalid Class File!`的问题，不带value是正常的，将`text.endsWith(WebAnnotation.Controller)`改成`text.contains(WebAnnotation.Controller)`既可以解决问题